### PR TITLE
add onSubmit adapter for EditText

### DIFF
--- a/library/src/main/java/se/ingenuity/databinding/adapter/EditTextBindingAdapter.kt
+++ b/library/src/main/java/se/ingenuity/databinding/adapter/EditTextBindingAdapter.kt
@@ -4,16 +4,13 @@ import android.view.KeyEvent
 import android.view.inputmethod.EditorInfo
 import android.widget.EditText
 import androidx.databinding.BindingAdapter
+import se.ingenuity.databinding.adapter.EditTextBindingAdapter.onFinishedEditing
 
 object EditTextBindingAdapter {
 
     @JvmStatic
-    @BindingAdapter("onFinishEditing")
-    fun setOnFinishEditing(view: EditText, onFinishEditing: () -> Unit) {
-        view.onFinishedEditing(onFinishEditing)
-    }
-
-    private fun EditText.onFinishedEditing(onFinishedEditing: () -> Unit) {
+    @BindingAdapter("onSubmit")
+    fun EditText.onSubmit(onSubmit: () -> Unit) {
         this.setOnEditorActionListener { _, actionId, event ->
             if (actionId == EditorInfo.IME_ACTION_SEARCH ||
                 actionId == EditorInfo.IME_ACTION_DONE ||
@@ -21,7 +18,7 @@ object EditTextBindingAdapter {
                 event.action == KeyEvent.ACTION_DOWN &&
                 event.keyCode == KeyEvent.KEYCODE_ENTER) {
                 if (event == null || !event.isShiftPressed) {
-                    onFinishedEditing()
+                    onSubmit()
                 }
             }
             false

--- a/library/src/main/java/se/ingenuity/databinding/adapter/EditTextBindingAdapter.kt
+++ b/library/src/main/java/se/ingenuity/databinding/adapter/EditTextBindingAdapter.kt
@@ -1,0 +1,31 @@
+package se.ingenuity.databinding.adapter
+
+import android.view.KeyEvent
+import android.view.inputmethod.EditorInfo
+import android.widget.EditText
+import androidx.databinding.BindingAdapter
+
+object EditTextBindingAdapter {
+
+    @JvmStatic
+    @BindingAdapter("onFinishEditing")
+    fun setOnFinishEditing(view: EditText, onFinishEditing: () -> Unit) {
+        view.onFinishedEditing(onFinishEditing)
+    }
+
+    private fun EditText.onFinishedEditing(onFinishedEditing: () -> Unit) {
+        this.setOnEditorActionListener { _, actionId, event ->
+            if (actionId == EditorInfo.IME_ACTION_SEARCH ||
+                actionId == EditorInfo.IME_ACTION_DONE ||
+                event != null &&
+                event.action == KeyEvent.ACTION_DOWN &&
+                event.keyCode == KeyEvent.KEYCODE_ENTER) {
+                if (event == null || !event.isShiftPressed) {
+                    onFinishedEditing()
+                }
+            }
+            false
+        }
+    }
+
+}


### PR DESCRIPTION
This adapter is used in many projects (Raven, Pngr, Cutters, Lederne, Sbanken, Tide..). Better to have it in one place. Useful for adding an action on Enter or IME_ACTION_DONE/SEARCH on an EditText view.